### PR TITLE
deps: fix the rgb-lib version

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -59,7 +59,7 @@ hex = "0.4"
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking"] }
 rgb-contracts = { version = "=0.10.2", features = ["electrum"] }
 rgb_core = { package = "rgb-core", version = "=0.10.8" }
-rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", branch = "master" }
+rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", branch = "rln_v0.10" }
 rgb-std = "=0.10.9"
 rgb-wallet = "=0.10.9"
 serde = { version = "^1.0", features = ["derive"] }


### PR DESCRIPTION
```
➜  rgb-lightning-node git:(master) cargo install --debug --path .
  Installing rgb-lightning-node v0.1.0 (/home/vincent/github/work/rgb-tools/rgb-lightning-node)
    Updating crates.io index
    Updating git repository `https://github.com/RGB-Tools/rgb-lib`
    Updating git repository `https://github.com/arik-so/rust-musig2`
error: failed to compile `rgb-lightning-node v0.1.0 (/home/vincent/github/work/rgb-tools/rgb-lightning-node)`, intermediate artifacts can be found at `/home/vincent/github/work/rgb-tools/rgb-lightning-node/target`

Caused by:
  failed to select a version for `strict_encoding`.
      ... required by package `lightning v0.0.118 (/home/vincent/github/work/rgb-tools/rgb-lightning-node/rust-lightning/lightning)`
      ... which satisfies path dependency `lightning` of package `rgb-lightning-node v0.1.0 (/home/vincent/github/work/rgb-tools/rgb-lightning-node)`
  versions that meet the requirements `=2.6.1` are: 2.6.1

  all possible versions conflict with previously selected packages.

    previously selected package `strict_encoding v2.6.2`
      ... which satisfies dependency `strict_encoding = "=2.6.2"` of package `rgb-lightning-node v0.1.0 (/home/vincent/github/work/rgb-tools/rgb-lightning-node)`
```