### PR TITLE
Reject out-of-range push_asset_amount in handle_funding

### DIFF
--- a/lightning/src/rgb_utils/mod.rs
+++ b/lightning/src/rgb_utils/mod.rs
@@ -664,11 +664,16 @@ pub(crate) fn handle_funding(
 		_ => unreachable!("unsupported schema"),
 	};
 	let push_amount = push_asset_amount.unwrap_or(0);
+	let remote_rgb_amount = channel_rgb_amount.checked_sub(push_amount).ok_or_else(|| {
+		ChannelError::close(format!(
+			"push_asset_amount {push_amount} exceeds channel asset amount {channel_rgb_amount}"
+		))
+	})?;
 	let rgb_info = RgbInfo {
 		contract_id: consignment.contract_id(),
 		schema: AssetSchema::from_schema_id(consignment.schema_id()).unwrap(),
 		local_rgb_amount: push_amount,
-		remote_rgb_amount: channel_rgb_amount - push_amount,
+		remote_rgb_amount,
 		batch_transfer_idx: None,
 		// only meaningful on the initiator side, which is the one that sends media
 		counterparty_knows_asset: false,


### PR DESCRIPTION

`handle_funding` computes the acceptor side RGB split as `remote_rgb_amount = channel_rgb_amount - push_amount`, where `push_amount` comes from the counterparty supplied `push_asset_amount` in `open_channel`. The value is not validated against `channel_rgb_amount`.

When a peer sends `push_asset_amount` greater than the funded asset amount the subtraction underflows. Release builds have overflow checks off, so the value wraps. The wrapped `remote_rgb_amount` is then passed to `color_psbt`, which returns `InvalidColoringInfo`, and the result is unwrapped. The panic poisons the channel manager mutex and the node stops serving channel operations until it is restarted.

The initiator side already rejects this in `rgb-lightning-node` before sending but the acceptor cannot rely on the counterparty running that check.

**Fix:** Reject `push_amount > channel_rgb_amount` in `handle_funding` before the subtraction, using the existing `ChannelError::close` path.