### PR TITLE
Fix payment hash collision in outbound BTC payments

### DIFF
--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -27,7 +27,7 @@ use crate::offers::invoice_request::InvoiceRequest;
 use crate::offers::nonce::Nonce;
 use crate::offers::static_invoice::StaticInvoice;
 use crate::rgb_utils::{
-	filter_first_hops, get_rgb_payment_info_path, is_payment_rgb, parse_rgb_payment_info,
+	filter_first_hops, get_rgb_payment_info_path, is_payment_rgb_out, parse_rgb_payment_info,
 };
 use crate::routing::router::{
 	BlindedTail, InFlightHtlcs, Path, PaymentParameters, Route, RouteParameters,
@@ -1049,7 +1049,7 @@ impl OutboundPayments {
 		}
 
 		let mut filtered_first_hops = first_hops.into_iter().collect::<Vec<_>>();
-		let rgb_payment = is_payment_rgb(&self.ldk_data_dir, &payment_hash).then(|| {
+		let rgb_payment = is_payment_rgb_out(&self.ldk_data_dir, &payment_hash).then(|| {
 			filter_first_hops(&self.ldk_data_dir, &payment_hash, &mut filtered_first_hops)
 		});
 		let mut route_params = RouteParameters::from_payment_params_and_value(
@@ -1569,7 +1569,7 @@ impl OutboundPayments {
 		SP: Fn(SendAlongPathArgs) -> Result<(), APIError>,
 	{
 		let mut filtered_first_hops = first_hops.into_iter().collect::<Vec<_>>();
-		is_payment_rgb(&self.ldk_data_dir, &payment_hash).then(|| {
+		is_payment_rgb_out(&self.ldk_data_dir, &payment_hash).then(|| {
 			filter_first_hops(&self.ldk_data_dir, &payment_hash, &mut filtered_first_hops)
 		});
 		let route = self.find_initial_route(
@@ -1626,7 +1626,7 @@ impl OutboundPayments {
 		}
 
 		let mut filtered_first_hops = first_hops.into_iter().collect::<Vec<_>>();
-		is_payment_rgb(&self.ldk_data_dir, &payment_hash).then(|| {
+		is_payment_rgb_out(&self.ldk_data_dir, &payment_hash).then(|| {
 			filter_first_hops(&self.ldk_data_dir, &payment_hash, &mut filtered_first_hops)
 		});
 

--- a/lightning/src/rgb_utils/mod.rs
+++ b/lightning/src/rgb_utils/mod.rs
@@ -742,10 +742,9 @@ pub(crate) fn update_rgb_channel_amount_pending(
 	)
 }
 
-/// Whether the payment is colored
-pub(crate) fn is_payment_rgb(ldk_data_dir: &Path, payment_hash: &PaymentHash) -> bool {
+/// Whether the outbound payment is colored.
+pub(crate) fn is_payment_rgb_out(ldk_data_dir: &Path, payment_hash: &PaymentHash) -> bool {
 	get_rgb_payment_info_path(payment_hash, ldk_data_dir, false).exists()
-		|| get_rgb_payment_info_path(payment_hash, ldk_data_dir, true).exists()
 }
 
 /// Detect the contract ID of the payment and then filter hops based on contract ID and amount


### PR DESCRIPTION
Restrict RGB payment detection to outbound payments.

The helper was renamed from `is_payment_rgb` to `is_payment_rgb_out` and now checks only the `.outbound` RGB metadata file.

The helper is used exclusively by outbound routing code:

- `send_payment_for_bolt12_invoice`
- `send_payment_for_non_bolt12_invoice`
- `find_route_and_send_payment`

No inbound payment handler calls this helper. Previously, the helper checked both `.outbound` and `.inbound`. If an inbound RGB payment and an outbound BTC payment reused the same payment hash, the outbound BTC payment could be incorrectly classified as RGB. This caused RGB-specific routing logic to run without outbound RGB metadata, leading to a panic.

The existing regression test `use_same_hodl_invoice_hash_for_inbound_rgb_and_outbound_btc`, included in https://github.com/RGB-Tools/rgb-lightning-node/pull/91, verifies that an inbound RGB HODL payment and an outbound BTC HODL payment can successfully use the same payment hash.